### PR TITLE
Tip to use older version of npm for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Install VueCLI: https://cli.vuejs.org/guide/installation.html
 5. `VUE_APP_API_BASE_URL` should contain the URL of your Laravel JSON:API Project. (eg. http://localhost:3000/api/v1)
 6. Run `npm run dev` to start the application in a local development environment or `npm run build`  to build release distributables.
 
+*Extra Note*
+- use `npx npm@6.14.16 install` if `npm install` failed. Ref: [StackOverflow](https://stackoverflow.com/a/68479189/5033470)
+
 ## Usage
 
 Register a user or login using admin@jsonapi.com and secret and start testing the theme.


### PR DESCRIPTION
Got an error of package-lock.json created with an older version of npm. So want to share the tip to overcome it.